### PR TITLE
Fix PDF export skill sanitization

### DIFF
--- a/src/components/pdf/PDFDownloader.tsx
+++ b/src/components/pdf/PDFDownloader.tsx
@@ -50,13 +50,10 @@ const PDFDownloader: React.FC<PDFDownloaderProps> = ({
     copy.certificates = Array.isArray(copy.certificates) ? copy.certificates : [];
     copy.languages = Array.isArray(copy.languages) ? copy.languages : [];
 
-    // Ensure skills object is defined
-    if (!copy.skills) {
+    // Ensure skills object is defined with the current structure
+    if (!copy.skills || typeof copy.skills.description !== 'string') {
       copy.skills = {
-        languages: [],
-        frameworks: [],
-        tools: [],
-        other: []
+        description: ''
       };
     }
 

--- a/src/components/preview/CVPreviewWithExport.tsx
+++ b/src/components/preview/CVPreviewWithExport.tsx
@@ -1,8 +1,6 @@
 'use client';
 
 import { useCVStore } from '@/lib/store/cv-store';
-import { Button } from "@/components/ui/button";
-import { Download } from "lucide-react";
 import dynamic from 'next/dynamic';
 
 // Dynamic import of PDF components that should only work on the client side


### PR DESCRIPTION
## Summary
- sanitize skills with new description field in PDFDownloader
- remove unused imports in CVPreviewWithExport

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684581750a688332932ba33efa173d57